### PR TITLE
feat: Add endpoint to serve all simulation cases

### DIFF
--- a/src/controllers/simulationController.js
+++ b/src/controllers/simulationController.js
@@ -78,3 +78,7 @@ export async function handleAsk(req, res) {
     // or we can accumulate it here. For simplicity, we won't accumulate it on the backend
     // in this example to keep the focus on streaming. A more robust solution would.
 }
+
+export function getAllCases(req, res) {
+    res.json(cases);
+}

--- a/src/routes/simulationRoutes.js
+++ b/src/routes/simulationRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { startSimulation, handleAsk } from '../controllers/simulationController.js';
+import { startSimulation, handleAsk, getAllCases } from '../controllers/simulationController.js';
 
 const router = express.Router();
 
@@ -7,5 +7,8 @@ router.post('/start', startSimulation);
 
 // CHANGE THIS LINE FROM .post to .get
 router.get('/ask', handleAsk);
+
+// Route to get all cases
+router.get('/cases', getAllCases);
 
 export default router;


### PR DESCRIPTION
This commit introduces a new GET endpoint `/api/simulation/cases` that provides all available simulation case data to the frontend.

- Added a new route `GET /cases` in `simulationRoutes.js`.
- Implemented a corresponding controller function `getAllCases` in `simulationController.js` which returns the already loaded case data.