### PR TITLE
feat: Implement case categorization API endpoints

### DIFF
--- a/src/routes/simulationRoutes.js
+++ b/src/routes/simulationRoutes.js
@@ -3,12 +3,14 @@ import {
   getCases, 
   startSimulation, 
   handleAsk,
-  endSession 
+  endSession,
+  getCaseCategories // Import the new controller function
 } from '../controllers/simulationController.js';
 
 const router = express.Router();
 
 router.get('/cases', getCases);
+router.get('/case-categories', getCaseCategories); // Add new route for categories
 router.post('/start', startSimulation);
 router.get('/ask', handleAsk);
 router.post('/end', endSession);  // End session endpoint


### PR DESCRIPTION
- Add GET /api/simulation/case-categories endpoint to return unique program and specialized areas for frontend filters.
- Enhance GET /api/simulation/cases endpoint to support filtering by `program_area` and `specialized_area` query parameters.