### PR TITLE
Fix: Align registration success response with frontend expectations

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -31,12 +31,14 @@ export async function register(req, res) {
 
     res.status(201).json({
       message: 'User registered successfully.',
-      token,
-      user: {
-        id: newUser._id,
-        username: newUser.username,
-        email: newUser.email,
-      },
+      data: { // Nest token and user under 'data'
+        token,
+        user: {
+          id: newUser._id,
+          username: newUser.username,
+          email: newUser.email,
+        },
+      }
     });
   } catch (error) {
     if (error instanceof mongoose.Error.ValidationError) {


### PR DESCRIPTION
Modified the POST /api/auth/register endpoint to nest the 'token' and 'user' objects under a 'data' key in the JSON response upon successful user registration.

This change addresses a TypeError on the frontend that occurred because it expected this nested structure while the backend was previously returning these fields at the root of the response.

Error response structures remain unchanged (i.e., error messages are at the root, not under a 'data' key).