### PR TITLE
Fix: Align login success response with frontend expectations

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -82,12 +82,14 @@ export async function login(req, res) {
 
     res.status(200).json({
       message: 'Login successful.',
-      token,
-      user: {
-        id: user._id,
-        username: user.username,
-        email: user.email,
-      },
+      data: { // Nest token and user under 'data'
+        token,
+        user: {
+          id: user._id,
+          username: user.username,
+          email: user.email,
+        },
+      }
     });
   } catch (error) {
     console.error('Error during login:', error);


### PR DESCRIPTION
Modified the POST /api/auth/login endpoint to nest the 'token' and 'user' objects under a 'data' key in the JSON response upon successful user login.

This change makes the login success response consistent with the registration success response and addresses potential TypeErrors on the frontend if it expected this nested structure for login as well.