### PR TITLE
Configure CORS to allow requests from specific origins

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,31 @@ connectDB();
 const app = express();
 const PORT = process.env.PORT || 5001;
 
-app.use(cors());
+// --- CORS Configuration ---
+const allowedOrigins = [
+  'https://kuiga.online', // Your production frontend
+  'http://localhost:3000', // Your local development frontend (if applicable)
+  'http://localhost:5173', // Another common local dev port (Vite)
+  // Add any other origins you need to allow
+];
+
+app.use(cors({
+  origin: function (origin, callback) {
+    // Allow requests with no origin (like mobile apps or curl requests)
+    if (!origin) return callback(null, true);
+    if (allowedOrigins.indexOf(origin) === -1) {
+      const msg = 'The CORS policy for this site does not allow access from the specified Origin.';
+      console.error(`CORS Error: Origin ${origin} not allowed.`); // Log CORS errors
+      return callback(new Error(msg), false);
+    }
+    return callback(null, true);
+  },
+  credentials: true, // Important if your frontend sends cookies or Authorization headers
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'], // Ensure 'Authorization' is included if you use tokens
+}));
+// --- End CORS Configuration ---
+
 app.use(express.json());
 
 // Mount Routers


### PR DESCRIPTION
This commit updates the CORS configuration in index.js to:
- Specify a list of allowed origins, including https://kuiga.online and common local development URLs.
- Enable credentials to be sent with requests.
- Define allowed HTTP methods and headers.

This should resolve the CORS policy errors you previously encountered when the frontend at https://kuiga.online attempted to communicate with the backend.