### PR TITLE
I've added `overall_score` and `performance_label` to the performance…

### DIFF
--- a/src/models/PerformanceMetricsModel.js
+++ b/src/models/PerformanceMetricsModel.js
@@ -25,7 +25,9 @@ const PerformanceMetricsSchema = new mongoose.Schema({
     differential_diagnosis_questioning_rating: { type: String, trim: true },
     communication_and_empathy_rating: { type: String, trim: true },
     clinical_urgency_rating: { type: String, trim: true },
-    overall_diagnosis_accuracy: { type: String, trim: true } // e.g., "Reached", "Missed", "Partially Reached"
+    overall_diagnosis_accuracy: { type: String, trim: true }, // e.g., "Reached", "Missed", "Partially Reached"
+    overall_score: { type: Number, default: null }, // Numerical score, e.g., 0-100
+    performance_label: { type: String, trim: true, default: null } // Qualitative label, e.g., "Excellent", "Good"
   },
   evaluation_summary: { // A brief summary, potentially extracted from the AI's "Summary & Recommendations"
     type: String,

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -124,7 +124,9 @@ function parseEvaluationMetrics(evaluationText) {
     communication_and_empathy_rating: "Not Available",
     clinical_urgency_rating: "Not Available",
     overall_diagnosis_accuracy: "Not Available",
-    evaluation_summary: "Not Available"
+    evaluation_summary: "Not Available",
+    overall_score: null, // Default to null for number
+    performance_label: "Not Available" // Default for string
   };
 
   if (!evaluationText || typeof evaluationText !== 'string') {
@@ -170,6 +172,20 @@ function parseEvaluationMetrics(evaluationText) {
     }
   }
 
+  // Extract Overall Performance Score
+  const scoreRegex = /Overall Performance Score:\s*(\d{1,3})\s*%/;
+  match = evaluationText.match(scoreRegex);
+  if (match && match[1]) {
+    metrics.overall_score = parseInt(match[1], 10);
+  }
+
+  // Extract Performance Label
+  const labelRegex = /Performance Label:\s*(Excellent|Very Good|Good|Needs Improvement|Poor)/;
+  match = evaluationText.match(labelRegex);
+  if (match && match[1]) {
+    metrics.performance_label = match[1];
+  }
+
   return metrics;
 }
 
@@ -213,6 +229,13 @@ export async function getEvaluation(caseData, conversationHistory) {
 
     For each criterion, assess whether the clinician's actions were Good, Needs Improvement, or Needs Significant Improvement. Provide specific examples from the conversation to support your assessment.
     Conclude with an overall "Summary & Recommendations" section, highlighting key strengths and areas for development, and explicitly stating whether the likely diagnosis of "${hiddenDiagnosis}" was reached or missed.
+    Finally, provide an "Overall Performance Score: [0-100]%" based on your holistic assessment of all criteria.
+    Based on this score, provide a "Performance Label: [Excellent/Very Good/Good/Needs Improvement/Poor]" using the following thresholds:
+    - 90-100: Excellent
+    - 80-89: Very Good
+    - 70-79: Good
+    - 60-69: Needs Improvement
+    - <60: Poor
 
     Desired Output Format:
     SESSION END
@@ -231,9 +254,12 @@ export async function getEvaluation(caseData, conversationHistory) {
     [Your detailed assessment for Clinical Urgency, referencing conversation specifics]
     Summary & Recommendations:
     [Your overall summary and recommendations, explicitly stating if the diagnosis of "${hiddenDiagnosis}" was reached or missed.]
+    Overall Performance Score: [The calculated score]%
+    Performance Label: [The determined label]
   `;
   // Note: Updated prompt to use patient_persona.name and ensure evaluation_criteria keys are flexible (e.g. History_Taking or history_taking)
   // Also explicitly asked to state if the hidden diagnosis was reached or missed in the summary.
+  // Added instructions for Overall Performance Score and Performance Label.
 
   try {
     const response = await openai.chat.completions.create({


### PR DESCRIPTION
… metrics.

Here's what I did:
- I updated `PerformanceMetricsModel` to include `overall_score` (Number) and `performance_label` (String) in the metrics sub-document.
- I modified the evaluation prompt in `aiService.js` to request an overall performance score (0-100%) and a qualitative performance label.
- I updated the parsing logic in `aiService.js` to extract these new fields from the evaluation text.
- I made sure that these new fields are saved as part of the `PerformanceMetrics` document when the session ends.
- These fields will now be available in the `GET /api/simulation/performance-metrics/session/:sessionId` API response.