### PR TITLE
feat: Redirect admin users to dashboard on login

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -81,6 +81,8 @@ export async function login(req, res) {
     log.info({ userId: user._id, email }, 'User logged in successfully.');
     const token = generateToken(user._id, user.username, user.role);
 
+    const redirectTo = user.role === 'admin' ? '/admin/dashboard' : '/';
+
     res.status(200).json({
       message: 'Login successful.',
       data: {
@@ -91,6 +93,7 @@ export async function login(req, res) {
           email: user.email,
           role: user.role,
         },
+        redirectTo,
       }
     });
   } catch (error) {


### PR DESCRIPTION
This change modifies the login API response to include a `redirectTo` field. For admin users, this field will be set to `/admin/dashboard`. For all other users, it will be set to `/`.

The frontend will need to be updated to handle this new field and redirect you accordingly.